### PR TITLE
test: request for Tobago 6

### DIFF
--- a/src/main/typescript/test/xhrCore/RequestTest.spec.ts
+++ b/src/main/typescript/test/xhrCore/RequestTest.spec.ts
@@ -558,5 +558,75 @@ describe('Tests after core when it hits response', function () {
     });
 
 
+    /**
+     * This test is based on Tobago 6 (Jakarte EE 9).
+     */
+    it("must handle ':' in IDs properly", function (done) {
+        window.document.body.innerHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<tobago-page locale="en" class="container-fluid" id="page" focus-on-error="true" wait-overlay-delay-full="1000" wait-overlay-delay-ajax="1000">
+    <form action="/content/010-input/10-in/In.xhtml?jfwid=q6qbeuqed" id="page::form" method="post" accept-charset="UTF-8" data-tobago-context-path="">
+        <input type="hidden" name="jakarta.faces.source" id="jakarta.faces.source" disabled="disabled">
+        <tobago-focus id="page::lastFocusId">
+            <input type="hidden" name="page::lastFocusId" id="page::lastFocusId::field">
+        </tobago-focus>
+        <input type="hidden" name="org.apache.myfaces.tobago.webapp.Secret" id="org.apache.myfaces.tobago.webapp.Secret" value="secretValue">
+        <tobago-in id="page:input" class="tobago-auto-spacing">
+            <input type="text" name="page:input" id="page:input::field" class="form-control" value="Bob">
+            <tobago-behavior event="change" client-id="page:input" field-id="page:input::field" execute="page:input" render="page:output"></tobago-behavior>
+        </tobago-in>
+        <tobago-out id="page:output" class="tobago-auto-spacing">
+            <span class="form-control-plaintext"></span>
+        </tobago-out>
+        <div class="tobago-page-menuStore">
+        </div>
+        <span id="page::faces-state-container">
+            <input type="hidden" name="jakarta.faces.ViewState" id="j_id__v_0:jakarta.faces.ViewState:1" value="viewStateValue" autocomplete="off">
+            <input type="hidden" name="jakarta.faces.RenderKitId" value="tobago">
+            <input type="hidden" id="j_id__v_0:jakarta.faces.ClientWindow:1" name="jakarta.faces.ClientWindow" value="clientWindowValue">
+        </span>
+    </form>
+</tobago-page>
+</body>
+</html>`;
+
+        //we now run the tests here
+        try {
+
+            let event = {
+                isTrusted: true,
+                type: 'change',
+                target: document.getElementById("page:input::field"),
+                currentTarget: document.getElementById("page:input::field")
+            };
+            faces.ajax.request(document.getElementById("page:input"), event as any, {
+                "jakarta.faces.behavior.event": 'change',
+                execute: "page:input",
+                render: "page:output"
+            });
+        } catch (err) {
+            console.error(err);
+            expect(false).to.eq(true);
+        }
+        const requestBody = this.requests[0].requestBody;
+        expect(requestBody.indexOf("org.apache.myfaces.tobago.webapp.Secret=secretValue")).to.not.eq(-1);
+        expect(requestBody.indexOf("page%3Ainput=Bob")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.ViewState=viewStateValue")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.RenderKitId=tobago")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.ClientWindow=clientWindowValue")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.behavior.event=change")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.partial.event=change")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.source=page%3Ainput")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.partial.ajax=true")).to.not.eq(-1);
+        expect(requestBody.indexOf("page%3A%3Aform=page%3A%3Aform")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.partial.execute=page%3Ainput")).to.not.eq(-1);
+        expect(requestBody.indexOf("jakarta.faces.partial.render=page%3Aoutput")).to.not.eq(-1);
+        done();
+    });
 });
 


### PR DESCRIPTION
The test fails because the IDs of jakarta.faces.partial.execute and jakarta.faces.partial.render contains '::' instead of ':'.