### PR TITLE
test: tobago file upload

### DIFF
--- a/src/main/typescript/test/frameworkBase/_ext/shared/StandardInits.ts
+++ b/src/main/typescript/test/frameworkBase/_ext/shared/StandardInits.ts
@@ -111,6 +111,38 @@ export module StandardInits {
 </html>`;
 
 
+    /**
+     * a page based on Tobago for a file upload
+     */
+    const HTML_TOBAGO_FILE_FORM = `<!DOCTYPE html>
+<html lang='de'>
+ <head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Test</title>
+ </head>
+ <body>
+  <tobago-page locale='de' class='container-fluid' id='page' focus-on-error='true' wait-overlay-delay-full='1000' wait-overlay-delay-ajax='1000'>
+   <form action='/content/100-upload/File_Upload.xhtml' id='page::form' method='post' enctype='multipart/form-data' accept-charset='UTF-8' data-tobago-context-path=''>
+    <input type='hidden' name='javax.faces.source' id='javax.faces.source' disabled='disabled'>
+    <tobago-focus id='page::lastFocusId'>
+     <input type='hidden' name='page::lastFocusId' id='page::lastFocusId::field'>
+    </tobago-focus>
+    <input type='hidden' name='org.apache.myfaces.tobago.webapp.Secret' id='org.apache.myfaces.tobago.webapp.Secret' value='secretValue'>
+    <tobago-file id='page:fileAjax' class='tobago-auto-spacing'>
+     <div class='input-group'>
+      <input type='file' tabindex='-1' id='page:fileAjax::field' class='form-control' name='page:fileAjax'>
+      <tobago-behavior event='change' client-id='page:fileAjax' field-id='page:fileAjax::field' execute='page:fileAjax'></tobago-behavior>
+      <label class='input-group-text' for='page:fileAjax::field'><span><i class='bi-folder2-open'></i></span></label>
+     </div>
+    </tobago-file>
+    <div class='tobago-page-menuStore'>
+    </div>
+    <span id='page::jsf-state-container'><input type='hidden' name='javax.faces.ViewState' id='j_id__v_0:javax.faces.ViewState:1' value='viewStateValue' autocomplete='off'><input type='hidden' name='javax.faces.RenderKitId' value='tobago'><input type='hidden' id='j_id__v_0:javax.faces.ClientWindow:1' name='javax.faces.ClientWindow' value='clientWindowValue'></span>
+   </form>
+  </tobago-page>
+ </body>
+</html>`;
 
     /**
      * a page simulating basically a simple faces form
@@ -349,6 +381,9 @@ export module StandardInits {
     }
     export function defaultFileForm(withJsf = true): Promise<() => void> {
         return init(HTML_FILE_FORM_DEFAULT, withJsf);
+    }
+    export function tobagoFileForm(withJsf = true): Promise<() => void> {
+        return init(HTML_TOBAGO_FILE_FORM, withJsf);
     }
     export function defaultFileForm_23(withJsf = true): Promise<() => void> {
         return init(HTML_FILE_FORM_DEFAULT.replace(/jakarta/gi, "javax"), withJsf, false);

--- a/src/main/typescript/test/xhrCore/TobagoFileUploadTest.spec.ts
+++ b/src/main/typescript/test/xhrCore/TobagoFileUploadTest.spec.ts
@@ -1,0 +1,109 @@
+/*! Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, it} from "mocha";
+import * as sinon from "sinon";
+import {expect} from "chai";
+import {StandardInits} from "../frameworkBase/_ext/shared/StandardInits";
+import {DomQuery} from "mona-dish";
+import {Implementation} from "../../impl/AjaxImpl";
+import defaultFileForm = StandardInits.tobagoFileForm;
+
+declare var faces: any;
+
+/**
+ * specialized tests testing the xhr core behavior when it hits the xmlHttpRequest object
+ */
+describe('Tests on the xhr core when it starts to call the request', function () {
+  beforeEach(async function () {
+
+    let waitForResult = defaultFileForm();
+    return waitForResult.then((close) => {
+
+      this.xhr = sinon.useFakeXMLHttpRequest();
+      this.requests = [];
+
+      this.respond = (response: string): XMLHttpRequest => {
+        let xhrReq = this.requests.shift();
+        xhrReq.responsetype = "text/xml";
+        xhrReq.respond(200, {'Content-Type': 'text/xml'}, response);
+        return xhrReq;
+      };
+
+      this.xhr.onCreate = (xhr) => {
+        this.requests.push(xhr);
+      };
+      (<any>global).XMLHttpRequest = this.xhr;
+      window.XMLHttpRequest = this.xhr;
+
+      this.closeIt = () => {
+        (<any>global).XMLHttpRequest = window.XMLHttpRequest = this.xhr.restore();
+        Implementation.reset();
+        close();
+      }
+    });
+
+  });
+  afterEach(function () {
+    this.closeIt();
+  });
+
+  it('tobago file upload', function (done) {
+    let send = sinon.spy(XMLHttpRequest.prototype, "send");
+
+    const POST = "POST";
+
+    try {
+      let fileUploadField = DomQuery.byId("page:fileAjax::field");
+      let actionElement = DomQuery.byId("page:fileAjax");
+
+      fileUploadField.addEventListener("change", (event: Event) => {
+        faces.ajax.request(
+            actionElement,
+            event,
+            {
+              "javax.faces.behavior.event": "change",
+              execute: 'page:fileAjax',
+              render: null
+            });
+      }).dispatchEvent(new Event("change"));
+
+      expect(this.requests.length).to.eq(1);
+      let request = this.requests[0];
+      expect(request.method).to.eq(POST);
+      expect(request.async).to.be.true;
+      expect(send.called).to.be.true;
+      expect(send.callCount).to.eq(1);
+      expect(request.requestBody instanceof FormData).to.be.true;
+
+      let formData: FormData = request.requestBody;
+      expect(formData.get("page::lastFocusId")).to.eq("");
+      expect(formData.get("org.apache.myfaces.tobago.webapp.Secret")).to.eq("secretValue");
+      expect(formData.get("javax.faces.ViewState")).to.eq("viewStateValue");
+      expect(formData.get("javax.faces.RenderKitId")).to.eq("tobago");
+      expect(formData.get("javax.faces.ClientWindow")).to.eq("clientWindowValue");
+      expect(formData.get("javax.faces.behavior.event")).to.eq("change");
+      expect(formData.get("jakarta.faces.partial.event")).to.eq("change");
+      expect(formData.get("jakarta.faces.source")).to.eq("page:fileAjax");
+      expect(formData.get("jakarta.faces.partial.ajax")).to.eq("true");
+      expect(formData.get("page::form")).to.eq("page::form");
+      expect(formData.get("jakarta.faces.partial.execute")).to.eq("page:fileAjax");
+
+    } finally {
+      send.restore();
+    }
+    done();
+  });
+});


### PR DESCRIPTION
With the RC34 the file upload doesn't work and leads to an "IllegalArgumentException: Last unit does not have enough valid bits". In the "network"-tab from the browser, you can see that every value in the form data is undefined.
The RC33 version works as expected.

I've added a test for the file upload in Tobago to cover this issue.