### PR TITLE
test: style tag must have 'nonce'

### DIFF
--- a/src/main/typescript/test/xhrCore/ResponseTest23.spec.ts
+++ b/src/main/typescript/test/xhrCore/ResponseTest23.spec.ts
@@ -375,6 +375,7 @@ describe('Tests of the various aspects of the response protocol functionality', 
 
         expect(DQ.querySelectorAll("head > style").length).to.be.eq(0);
         expect(DQ.querySelectorAll("body tobago-page tobago-sheet > style").length).to.be.eq(1);
+        expect(DQ.querySelectorAll("body tobago-page tobago-sheet > style")[0].nonce).to.be.eq("nonceValue");
     });
 
     


### PR DESCRIPTION
Extends the "<style> element must be in <tobago-sheet> instead of <head>" test, to check the 'nonce' value.