### PR TITLE
test: tobago tree select

### DIFF
--- a/src/main/typescript/test/xhrCore/RequestParamsTest.spec.ts
+++ b/src/main/typescript/test/xhrCore/RequestParamsTest.spec.ts
@@ -265,4 +265,196 @@ describe("test for proper request param patterns identical to the old implementa
         done();
     });
 
+    /**
+     * This test is based on Tobago 6.0.0 (Jakarte EE 10).
+     */
+    it("tobago tree select", function (done) {
+        window.document.body.innerHTML = `
+<tobago-page locale='de' class='container-fluid' id='page' focus-on-error='true' wait-overlay-delay-full='1000' wait-overlay-delay-ajax='1000'>
+   <form action='/content/090-tree/01-select/Tree_Select.xhtml' id='page::form' method='post' accept-charset='UTF-8' data-tobago-context-path=''>
+    <input type='hidden' name='jakarta.faces.source' id='jakarta.faces.source' disabled='disabled'>
+    <tobago-focus id='page::lastFocusId'>
+     <input type='hidden' name='page::lastFocusId' id='page::lastFocusId::field'>
+    </tobago-focus>
+    <input type='hidden' name='org.apache.myfaces.tobago.webapp.Secret' id='org.apache.myfaces.tobago.webapp.Secret' value='secretValue'>
+    <div class='tobago-page-menuStore'>
+    </div>
+    <div class='tobago-page-toastStore'>
+    </div>
+    <span id='page::faces-state-container'><input type='hidden' name='jakarta.faces.ViewState' id='j_id__v_0:jakarta.faces.ViewState:1' value='viewStateValue' autocomplete='off'><input type='hidden' name='jakarta.faces.RenderKitId' value='tobago'><input type='hidden' id='j_id__v_0:jakarta.faces.ClientWindow:1' name='jakarta.faces.ClientWindow' value='clientWindowValue'></span>
+    <tobago-tree id='page:categoriesTree' data-tobago-selectable='multi' selectable='multi'>
+<tobago-tree-node id='page:categoriesTree:0:j_id_3' class='tobago-folder tobago-expanded' expandable='expandable' index='0' data-tobago-level='0'>
+<span id='page:categoriesTree:0:j_id_4' class='tobago-toggle'><i class='bi-dash-square' data-tobago-open='bi-dash-square' data-tobago-closed='bi-plus-square'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:0:select' value='page:categoriesTree:0:select' id='page:categoriesTree:0:select'>
+<label class='form-check-label' for='page:categoriesTree:0:select'>Category</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:0:select' execute='page:categoriesTree:0:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:1:j_id_3' index='1' data-tobago-tree-parent='page:categoriesTree:0:j_id_3' parent='page:categoriesTree:0:j_id_3' data-tobago-level='1'>
+<span id='page:categoriesTree:1:j_id_4' class='tobago-toggle invisible'><i class='bi-square invisible'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:1:select' value='page:categoriesTree:1:select' id='page:categoriesTree:1:select'>
+<label class='form-check-label' for='page:categoriesTree:1:select'>Sports</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:1:select' execute='page:categoriesTree:1:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:2:j_id_3' index='2' data-tobago-tree-parent='page:categoriesTree:0:j_id_3' parent='page:categoriesTree:0:j_id_3' data-tobago-level='1'>
+<span id='page:categoriesTree:2:j_id_4' class='tobago-toggle invisible'><i class='bi-square invisible'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:2:select' value='page:categoriesTree:2:select' id='page:categoriesTree:2:select'>
+<label class='form-check-label' for='page:categoriesTree:2:select'>Movies</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:2:select' execute='page:categoriesTree:2:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:3:j_id_3' class='tobago-selected tobago-folder tobago-expanded' selected='selected' expandable='expandable' index='3' data-tobago-tree-parent='page:categoriesTree:0:j_id_3' parent='page:categoriesTree:0:j_id_3' data-tobago-level='1'>
+<span id='page:categoriesTree:3:j_id_4' class='tobago-toggle'><i class='bi-dash-square' data-tobago-open='bi-dash-square' data-tobago-closed='bi-plus-square'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:3:select' value='page:categoriesTree:3:select' id='page:categoriesTree:3:select' checked='checked'>
+<label class='form-check-label' for='page:categoriesTree:3:select'>Music</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:3:select' execute='page:categoriesTree:3:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:4:j_id_3' index='4' data-tobago-tree-parent='page:categoriesTree:3:j_id_3' parent='page:categoriesTree:3:j_id_3' data-tobago-level='2'>
+<span id='page:categoriesTree:4:j_id_4' class='tobago-toggle invisible'><i class='bi-square invisible'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:4:select' value='page:categoriesTree:4:select' id='page:categoriesTree:4:select'>
+<label class='form-check-label' for='page:categoriesTree:4:select'>Classic</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:4:select' execute='page:categoriesTree:4:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:5:j_id_3' index='5' data-tobago-tree-parent='page:categoriesTree:3:j_id_3' parent='page:categoriesTree:3:j_id_3' data-tobago-level='2'>
+<span id='page:categoriesTree:5:j_id_4' class='tobago-toggle invisible'><i class='bi-square invisible'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:5:select' value='page:categoriesTree:5:select' id='page:categoriesTree:5:select'>
+<label class='form-check-label' for='page:categoriesTree:5:select'>Pop</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:5:select' execute='page:categoriesTree:5:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:6:j_id_3' class='tobago-folder' expandable='expandable' index='6' data-tobago-tree-parent='page:categoriesTree:3:j_id_3' parent='page:categoriesTree:3:j_id_3' data-tobago-level='2'>
+<span id='page:categoriesTree:6:j_id_4' class='tobago-toggle'><i class='bi-plus-square' data-tobago-open='bi-dash-square' data-tobago-closed='bi-plus-square'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:6:select' value='page:categoriesTree:6:select' id='page:categoriesTree:6:select'>
+<label class='form-check-label' for='page:categoriesTree:6:select'>World</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:6:select' execute='page:categoriesTree:6:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:7:j_id_3' index='7' data-tobago-tree-parent='page:categoriesTree:0:j_id_3' parent='page:categoriesTree:0:j_id_3' data-tobago-level='1'>
+<span id='page:categoriesTree:7:j_id_4' class='tobago-toggle invisible'><i class='bi-square invisible'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:7:select' value='page:categoriesTree:7:select' id='page:categoriesTree:7:select'>
+<label class='form-check-label' for='page:categoriesTree:7:select'>Games</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:7:select' execute='page:categoriesTree:7:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:8:j_id_3' class='tobago-folder tobago-expanded' expandable='expandable' index='8' data-tobago-tree-parent='page:categoriesTree:0:j_id_3' parent='page:categoriesTree:0:j_id_3' data-tobago-level='1'>
+<span id='page:categoriesTree:8:j_id_4' class='tobago-toggle'><i class='bi-dash-square' data-tobago-open='bi-dash-square' data-tobago-closed='bi-plus-square'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:8:select' value='page:categoriesTree:8:select' id='page:categoriesTree:8:select'>
+<label class='form-check-label' for='page:categoriesTree:8:select'>Science</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:8:select' execute='page:categoriesTree:8:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:9:j_id_3' class='tobago-folder' expandable='expandable' index='9' data-tobago-tree-parent='page:categoriesTree:8:j_id_3' parent='page:categoriesTree:8:j_id_3' data-tobago-level='2'>
+<span id='page:categoriesTree:9:j_id_4' class='tobago-toggle'><i class='bi-plus-square' data-tobago-open='bi-dash-square' data-tobago-closed='bi-plus-square'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:9:select' value='page:categoriesTree:9:select' id='page:categoriesTree:9:select'>
+<label class='form-check-label' for='page:categoriesTree:9:select'>Mathematics</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:9:select' execute='page:categoriesTree:9:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:10:j_id_3' index='10' data-tobago-tree-parent='page:categoriesTree:8:j_id_3' parent='page:categoriesTree:8:j_id_3' data-tobago-level='2'>
+<span id='page:categoriesTree:10:j_id_4' class='tobago-toggle invisible'><i class='bi-square invisible'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:10:select' value='page:categoriesTree:10:select' id='page:categoriesTree:10:select'>
+<label class='form-check-label' for='page:categoriesTree:10:select'>Geography</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:10:select' execute='page:categoriesTree:10:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<tobago-tree-node id='page:categoriesTree:11:j_id_3' class='tobago-folder' expandable='expandable' index='11' data-tobago-tree-parent='page:categoriesTree:8:j_id_3' parent='page:categoriesTree:8:j_id_3' data-tobago-level='2'>
+<span id='page:categoriesTree:11:j_id_4' class='tobago-toggle'><i class='bi-plus-square' data-tobago-open='bi-dash-square' data-tobago-closed='bi-plus-square'></i></span>
+<tobago-tree-select class='form-check-inline form-check'>
+<input class='form-check-input' type='checkbox' name='page:categoriesTree:11:select' value='page:categoriesTree:11:select' id='page:categoriesTree:11:select'>
+<label class='form-check-label' for='page:categoriesTree:11:select'>Astronomy</label>
+<tobago-behavior event='change' client-id='page:categoriesTree:11:select' execute='page:categoriesTree:11:select page:categoriesTree' render='page:selectedNodesOutput page:categoriesTree'></tobago-behavior>
+</tobago-tree-select>
+</tobago-tree-node>
+<input type='hidden' name='page:categoriesTree::selected' id='page:categoriesTree::selected' class='tobago-selected' value='[3]'>
+<input type='hidden' name='page:categoriesTree::expanded' id='page:categoriesTree::expanded' class='tobago-expanded' value='[0,3,8]'>
+<tobago-scroll>
+<input id='page:categoriesTree::scrollPosition' name='page:categoriesTree::scrollPosition' type='hidden' value='[0,0]' data-tobago-scroll-position='true'>
+</tobago-scroll>
+</tobago-tree>
+    <tobago-out id='page:selectedNodesOutput' class='tobago-label-container tobago-auto-spacing'><label for='page:selectedNodesOutput' class='col-form-label'>Selected Nodes</label><span class='form-control-plaintext'>Music</span></tobago-out>
+   </form>
+   <noscript>
+    <div class='tobago-page-noscript'>Diese Seite benötigt JavaScript, allerdings ist JavaScript in Ihrem Browser derzeit deaktiviert. Um JavaScript zu aktivieren, lesen Sie ggf. die Anleitung Ihres Browsers.
+    </div>
+   </noscript>
+  </tobago-page>
+`;
+
+        //we now run the tests here
+        try {
+            let event = {
+                isTrusted: true,
+                type: 'change',
+                target: document.getElementById("page:categoriesTree:3:select"),
+                currentTarget: document.getElementById("page:categoriesTree:3:select")
+            };
+            global.debug2 = true;
+            faces.ajax.request(
+                document.getElementById("page:categoriesTree:3:select"),
+                event as any,
+                {
+                    "jakarta.faces.behavior.event": "change",
+                    execute: 'page:categoriesTree:3:select page:categoriesTree',
+                    render: 'page:selectedNodesOutput page:categoriesTree'
+                });
+        } catch (err) {
+            console.error(err);
+            expect(false).to.eq(true);
+        }
+        const requestBody = this.requests[0].requestBody;
+        let arsArr = requestBody.split("&");
+        let resultsMap = {};
+        for (let val of arsArr) {
+            let keyVal = val.split("=");
+
+            if (resultsMap[keyVal[0]]) {
+                console.log("duplicated key '" + keyVal[0] + "'");
+                expect(resultsMap[keyVal[0]]).not.to.exist;
+            }
+
+            resultsMap[keyVal[0]] = keyVal[1];
+        }
+
+        function encode(string: string): string {
+            return string
+                .split(" ").join("%20")
+                .split(",").join("%2C")
+                .split(":").join("%3A")
+                .split("[").join("%5B")
+                .split("]").join("%5D");
+        }
+
+        expect(resultsMap[encode("page::lastFocusId")]).to.exist;
+        expect(resultsMap["org.apache.myfaces.tobago.webapp.Secret"]).to.eq("secretValue");
+        expect(resultsMap["jakarta.faces.ViewState"]).to.eq("viewStateValue");
+        expect(resultsMap["jakarta.faces.RenderKitId"]).to.eq("tobago");
+        expect(resultsMap["jakarta.faces.ClientWindow"]).to.eq("clientWindowValue");
+        expect(resultsMap[encode("page:categoriesTree::selected")]).to.eq(encode("[3]"));
+        expect(resultsMap[encode("page:categoriesTree::expanded")]).to.eq(encode("[0,3,8]"));
+        expect(resultsMap[encode("page:categoriesTree::scrollPosition")]).to.eq(encode("[0,0]"));
+        expect(resultsMap["jakarta.faces.behavior.event"]).to.eq("change");
+        expect(resultsMap["jakarta.faces.partial.event"]).to.eq("change");
+        expect(resultsMap["jakarta.faces.source"]).to.eq(encode("page:categoriesTree:3:select"));
+        expect(resultsMap["jakarta.faces.partial.ajax"]).to.eq("true");
+        expect(resultsMap[encode("page::form")]).to.eq(encode("page::form"));
+        expect(resultsMap["jakarta.faces.partial.execute"]).to.eq(encode("page:categoriesTree:3:select page:categoriesTree"));
+        expect(resultsMap["jakarta.faces.partial.render"]).to.eq(encode("page:selectedNodesOutput page:categoriesTree"));
+        expect(resultsMap[encode("page:categoriesTree:3:select")]).not.to.exist;
+
+        done();
+    });
 });


### PR DESCRIPTION
Added a test for the Tobago tc:treeSelect component based on Tobago 6.0.0. A demo can be found here: https://tobago-demo.apache.org/demo-6-snapshot/content/090-tree/01-select/Tree_Select.xhtml The test is based on this demo.

Tobago 6.0.0 uses jsf.js_next_gen 4.0.1-beta.9, which works for tc:treeSelect. Starting with 4.0.2-beta.1, the request form data contains "page:categoriesTree:3:select: page:categoriesTree:3:select". This leads to the issue that a checkbox can be selected but not deselected.

The test might be not optimal, as it fails on 4.0.1-beta.9.

There is a minor issue where the key "jakarta.faces.ClientWindow" is duplicated.