### PR TITLE
test: ajax on tobago-page

### DIFF
--- a/src/main/typescript/test/frameworkBase/_ext/shared/StandardInits.ts
+++ b/src/main/typescript/test/frameworkBase/_ext/shared/StandardInits.ts
@@ -231,6 +231,41 @@ export module StandardInits {
 </body>
 </html>`;
 
+    export const HTML_TOBAGO_PAGE_WITH_BUTTON = `<!DOCTYPE html>
+<html lang='de'>
+ <head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Test
+  </title>
+  <link rel='stylesheet' href='./fixtures/css/tobago.css' type='text/css'>
+  <link rel='stylesheet' href='./fixtures/css/bootstrap-icons.css' type='text/css'>
+  <script src='./fixtures/jakarta.faces.resource/faces.js.jsf' type='text/javascript'></script>
+  <script src='./fixtures/js/tobago.js' type='module'></script>
+ </head>
+ <body>
+  <tobago-page locale='de' class='container-fluid' id='page' focus-on-error='true' wait-overlay-delay-full='1000' wait-overlay-delay-ajax='1000'>
+   <form action='/content/010-input/Input.xhtml' id='page::form' method='post' accept-charset='UTF-8' data-tobago-context-path=''>
+    <input type='hidden' name='jakarta.faces.source' id='jakarta.faces.source' disabled='disabled'>
+    <tobago-focus id='page::lastFocusId'>
+     <input type='hidden' name='page::lastFocusId' id='page::lastFocusId::field'>
+    </tobago-focus>
+    <input type='hidden' name='org.apache.myfaces.tobago.webapp.Secret' id='org.apache.myfaces.tobago.webapp.Secret' value='secretValue'>
+    <div class='tobago-page-menuStore'>
+    </div>
+    <div class='tobago-page-toastStore'>
+    </div>
+    <span id='page::faces-state-container'><input type='hidden' name='jakarta.faces.ViewState' id='j_id__v_0:jakarta.faces.ViewState:1' value='viewStateValue' autocomplete='off'><input type='hidden' name='jakarta.faces.RenderKitId' value='tobago'><input type='hidden' id='j_id__v_0:jakarta.faces.ClientWindow:1' name='jakarta.faces.ClientWindow' value='clientWindowValue'></span>
+    <button type='button' id='page:button' name='page:button' class='tobago-button btn btn-secondary tobago-auto-spacing'><tobago-behavior event='click' client-id='page:button' execute='page:button' render='page'></tobago-behavior><span>page ajax</span></button>
+   </form>
+   <noscript>
+    <div class='tobago-page-noscript'>Diese Seite benötigt JavaScript, allerdings ist JavaScript in Ihrem Browser derzeit deaktiviert. Um JavaScript zu aktivieren, lesen Sie ggf. die Anleitung Ihres Browsers.
+    </div>
+   </noscript>
+  </tobago-page>
+ </body>
+</html>`;
+
     /**
      * a page simulating basically a simple faces form
      */

--- a/src/main/typescript/test/frameworkBase/_ext/shared/XmlResponses.ts
+++ b/src/main/typescript/test/frameworkBase/_ext/shared/XmlResponses.ts
@@ -79,6 +79,51 @@ export class XmlResponses {
   </changes>
 </partial-response>`;
 
+    static UPDATE_TOBAGO_PAGE_WITH_BUTTON = `<?xml version="1.0" encoding="UTF-8"?>
+<partial-response id='j_id__v_0'>
+  <changes>
+    <update id='page'><![CDATA[
+<html lang='de'>
+<head>
+<meta charset='UTF-8'/>
+<meta name='viewport' content='width=device-width, initial-scale=1.0'/>
+<title>Test
+</title>
+<link rel='stylesheet' href='./fixtures/css/tobago.css' type='text/css'>
+<link rel='stylesheet' href='./fixtures/css/bootstrap-icons.css' type='text/css'>
+<script src='./fixtures/jakarta.faces.resource/faces.js.jsf' type='text/javascript'></script>
+<script src='./fixtures/js/tobago.js' type='module'></script>
+</head>
+<body>
+<tobago-page locale='de' class='container-fluid' id='page' focus-on-error='true' wait-overlay-delay-full='1000' wait-overlay-delay-ajax='1000'>
+<form action='/content/010-input/Input.xhtml' id='page::form' method='post' accept-charset='UTF-8' data-tobago-context-path=''>
+<input type='hidden' name='jakarta.faces.source' id='jakarta.faces.source' disabled='disabled'/>
+<tobago-focus id='page::lastFocusId'>
+<input type='hidden' name='page::lastFocusId' id='page::lastFocusId::field'/>
+</tobago-focus>
+<input type='hidden' name='org.apache.myfaces.tobago.webapp.Secret' id='org.apache.myfaces.tobago.webapp.Secret' value='secretValue'/>
+<div class='tobago-page-menuStore'>
+</div>
+<div class='tobago-page-toastStore'>
+</div>
+<span id='page::faces-state-container'></span>
+<button type='button' id='page:button' name='page:button' class='tobago-button btn btn-secondary tobago-auto-spacing'><tobago-behavior event='click' client-id='page:button' execute='page:button' render='page'></tobago-behavior><span>page ajax</span></button>
+</form>
+<noscript>
+<div class='tobago-page-noscript'>Diese Seite benötigt JavaScript, allerdings ist JavaScript in Ihrem Browser derzeit deaktiviert. Um JavaScript zu aktivieren, lesen Sie ggf. die Anleitung Ihres Browsers.
+</div>
+</noscript>
+</tobago-page>
+</body>
+</html>]]>
+    </update>
+    <update id='j_id__v_0:jakarta.faces.ViewState:1'><![CDATA[viewStateValue]]>
+    </update>
+    <update id='j_id__v_0:jakarta.faces.ClientWindow:1'><![CDATA[clientWindowValue]]>
+    </update>
+  </changes>
+</partial-response>`;
+
     static SHADOW_DOM_UPDATE=`
         <partial-response>
             <changes><update id="shadowContent"><![CDATA[<div id="shadowContent">after update</div>]]></update></changes>

--- a/src/main/typescript/test/xhrCore/ResponseTest.spec.ts
+++ b/src/main/typescript/test/xhrCore/ResponseTest.spec.ts
@@ -765,5 +765,23 @@ describe('Tests of the various aspects of the response protocol functionality', 
 
     });
 
+    it("Count of <html> and <body> must be 1", function () {
+        window.document.documentElement.innerHTML = StandardInits.HTML_TOBAGO_PAGE_WITH_BUTTON;
+
+        expect(DQ.querySelectorAll("html").length).to.be.eq(1);
+        expect(DQ.querySelectorAll("body").length).to.be.eq(1);
+
+        faces.ajax.request(window.document.getElementById("page:button"), null, {
+            "jakarta.faces.behavior.event": "click",
+            execute: "page:button",
+            render: "page"
+        });
+
+        this.respond(XmlResponses.UPDATE_TOBAGO_PAGE_WITH_BUTTON);
+
+        expect(DQ.querySelectorAll("html").length).to.be.eq(1);
+        expect(DQ.querySelectorAll("body").length).to.be.eq(1);
+    });
+
 
 });


### PR DESCRIPTION
A response for <tobago-page> should only replace it. Currently instead of "<tobago-page>..." the whole "<html>..." is inserted. After the ajax response, there are two <html> and two <body> tags. The <head> is duplicated too.